### PR TITLE
fix Linux build

### DIFF
--- a/glutin/src/platform/unix.rs
+++ b/glutin/src/platform/unix.rs
@@ -13,7 +13,10 @@ pub use glutin_egl_sys::EGLContext;
 #[cfg(feature = "x11")]
 pub use glutin_glx_sys::GLXContext;
 
-pub use winit::platform::unix::*;
+#[cfg(feature = "wayland")]
+pub use winit::platform::wayland::{self, EventLoopWindowTargetExtWayland, WindowExtWayland};
+#[cfg(feature = "x11")]
+pub use winit::platform::x11::{self, EventLoopWindowTargetExtX11, WindowBuilderExtX11, WindowExtX11};
 
 use std::os::raw;
 

--- a/glutin/src/platform_impl/unix/mod.rs
+++ b/glutin/src/platform_impl/unix/mod.rs
@@ -24,7 +24,10 @@ pub use x11::utils as x11_utils;
 
 #[cfg(feature = "x11")]
 use crate::platform::unix::x11::XConnection;
-use crate::platform::unix::EventLoopWindowTargetExtUnix;
+#[cfg(feature = "wayland")]
+use winit::platform::wayland::EventLoopWindowTargetExtWayland;
+#[cfg(feature = "x11")]
+use winit::platform::x11::EventLoopWindowTargetExtX11;
 use winit::dpi;
 use winit::event_loop::EventLoopWindowTarget;
 use winit::window::{Window, WindowBuilder};

--- a/glutin/src/platform_impl/unix/wayland.rs
+++ b/glutin/src/platform_impl/unix/wayland.rs
@@ -5,7 +5,7 @@ use crate::{
     ContextError, CreationError, GlAttributes, PixelFormat, PixelFormatRequirements, Rect,
 };
 
-use crate::platform::unix::{EventLoopWindowTargetExtUnix, WindowExtUnix};
+use crate::platform::unix::{EventLoopWindowTargetExtWayland, WindowExtWayland};
 use glutin_egl_sys as ffi;
 pub use wayland_client::sys::client::wl_display;
 use winit;

--- a/glutin/src/platform_impl/unix/x11.rs
+++ b/glutin/src/platform_impl/unix/x11.rs
@@ -5,7 +5,7 @@ use crate::api::egl::{
 };
 use crate::api::glx::{Context as GlxContext, GLX};
 use crate::platform::unix::x11::XConnection;
-use crate::platform::unix::{EventLoopWindowTargetExtUnix, WindowBuilderExtUnix, WindowExtUnix};
+use crate::platform::unix::{EventLoopWindowTargetExtX11, WindowBuilderExtX11, WindowExtX11};
 use crate::platform_impl::x11_utils;
 use crate::{
     Api, ContextError, CreationError, GlAttributes, GlRequest, PixelFormat,
@@ -462,7 +462,7 @@ impl Context {
             EglSurfaceType::Window,
             fallback,
             fallback,
-            Some(wb.window.transparent),
+            Some(wb.transparent()),
         )?;
 
         // getting the `visual_infos` (a struct that contains information about


### PR DESCRIPTION
Fixed linux build by re-exporting some of the structs defined in `winit`.

Requires https://github.com/neovide/winit/pull/11